### PR TITLE
Update "Relation to the IETF LLC"

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -345,15 +345,32 @@ NOT be shared between the teams.
 
 The Board of Directors of the IETF Administration LLC (IETF LLC) has
 fiduciary duty for the overall organization, which includes the duty
-to protect the organization from legal risk that may arise from
-illegal, vulgar, or manifestly harassing behavior of IETF participants.
+to protect the organization from serious legal risk that may arise 
+from the behavior of IETF participants.
 
-This protection MAY include the need for the LLC to take emergency moderation
-actions. These emergency actions are expected to be extremely rare, of temporary
-nature, and the incidents that required them SHOULD be immediately raised with
-the moderator team to let them determine any follow-up or more permanent
-moderation action. These incidents and the taken emergency action SHOULD also be
-communicated to the IETF community.
+This protection MAY include the need for the IETF LLC to take 
+emergency moderation actions. These emergency actions are expected to 
+be taken only when the IETF LLC has received legal advice that such 
+action is necessary, and therefore extremely rare in frequency. Some
+examples of where this might be necessary are:
+
+- Someone making credible threat of harm to other IETF participants.
+- Someone using IETF mailing lists and/or websites to share content
+  where publishing that content on IETF lists and/or websites brings
+  serious legal risk. 
+- Someone making credible threats of legal action where any form of
+  interaction with them on IETF mailing lists may have serious legal 
+  consequences for the IETF.
+
+If any such action is taken, the IETF LLC MUST inform the IESG as 
+soon as possible and SHOULD provide full details of the subject of 
+the action, nature of the action, reason for the action and expected 
+duration, except where it receives legal advice to the contrary. The 
+IETF LLC SHOULD also inform the moderator team and IETF community, 
+except where it receives legal advice to the contrary. 
+
+Any such action taken by the IETF under this section of this policy, 
+is not subject to the rest of the policy in this document
 
 # Changes to Existing RFCs
 

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -370,9 +370,9 @@ IETF LLC SHOULD also inform the moderator team and IETF community,
 except where it receives legal advice to the contrary. 
 
 As such an action would be taken by the IETF LLC in order to protect 
-the IETF according to its fiduciary duty, then it cannot be 
-overridden by a decision of the moderation team or the IESG. The 
-subject of any such action may request a review by the IETF LLC 
+the IETF according to its fiduciary duty, then it cannot allow that 
+to be overridden by a decision of the moderation team or the IESG. 
+The subject of any such action may request a review by the IETF LLC 
 board, as documented in section 4.7 of {{!RFC8711}}
 
 Any such action taken by the IETF LLC under this section of this 

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -337,11 +337,11 @@ examples of where this might be necessary are:
   interaction with them on IETF mailing lists may have serious legal
   consequences for the IETF.
 
-If any such action is taken, the IETF LLC SHOULD, except where 
-limited by legal advice to the contrary, inform the IESG as soon as 
+If any such action is taken, the IETF LLC SHOULD, except where
+limited by legal advice to the contrary, inform the IESG as soon as
 possible, providing full details of the subject of the action, nature
-of the action, reason for the action and expected duration. The IETF 
-LLC SHOULD also inform the moderator team and IETF community, except 
+of the action, reason for the action and expected duration. The IETF
+LLC SHOULD also inform the moderator team and IETF community, except
 where it receives legal advice to the contrary.
 
 As such an action would be taken by the IETF LLC in order to protect

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -325,12 +325,12 @@ examples of where this might be necessary are:
   interaction with them on IETF mailing lists may have serious legal
   consequences for the IETF.
 
-If any such action is taken, the IETF LLC SHOULD inform the IESG as
-soon as possible and SHOULD provide full details of the subject of
-the action, nature of the action, reason for the action and expected
-duration, except where it receives legal advice to the contrary. The
-IETF LLC SHOULD also inform the moderator team and IETF community,
-except where it receives legal advice to the contrary.
+If any such action is taken, the IETF LLC SHOULD, except where 
+limited by legal advice to the contrary, inform the IESG as soon as 
+possible, providing full details of the subject of the action, nature
+of the action, reason for the action and expected duration. The IETF 
+LLC SHOULD also inform the moderator team and IETF community, except 
+where it receives legal advice to the contrary.
 
 As such an action would be taken by the IETF LLC in order to protect
 the IETF according to its fiduciary duty, then it cannot allow that

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -362,15 +362,21 @@ examples of where this might be necessary are:
   interaction with them on IETF mailing lists may have serious legal 
   consequences for the IETF.
 
-If any such action is taken, the IETF LLC MUST inform the IESG as 
+If any such action is taken, the IETF LLC SHOULD inform the IESG as 
 soon as possible and SHOULD provide full details of the subject of 
 the action, nature of the action, reason for the action and expected 
 duration, except where it receives legal advice to the contrary. The 
 IETF LLC SHOULD also inform the moderator team and IETF community, 
 except where it receives legal advice to the contrary. 
 
-Any such action taken by the IETF under this section of this policy, 
-is not subject to the rest of the policy in this document
+As such an action would be taken by the IETF LLC in order to protect 
+the IETF according to its fiduciary duty, then it cannot be 
+overridden by a decision of the moderation team or the IESG. The 
+subject of any such action may request a review by the IETF LLC 
+board, as documented in section 4.7 of {{!RFC8711}}
+
+Any such action taken by the IETF LLC under this section of this 
+policy, is not subject to the rest of the policy in this document.
 
 # Changes to Existing RFCs
 

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -345,37 +345,37 @@ NOT be shared between the teams.
 
 The Board of Directors of the IETF Administration LLC (IETF LLC) has
 fiduciary duty for the overall organization, which includes the duty
-to protect the organization from serious legal risk that may arise 
+to protect the organization from serious legal risk that may arise
 from the behavior of IETF participants.
 
-This protection MAY include the need for the IETF LLC to take 
-emergency moderation actions. These emergency actions are expected to 
-be taken only when the IETF LLC has received legal advice that such 
+This protection MAY include the need for the IETF LLC to take
+emergency moderation actions. These emergency actions are expected to
+be taken only when the IETF LLC has received legal advice that such
 action is necessary, and therefore extremely rare in frequency. Some
 examples of where this might be necessary are:
 
 - Someone making credible threat of harm to other IETF participants.
 - Someone using IETF mailing lists and/or websites to share content
   where publishing that content on IETF lists and/or websites brings
-  serious legal risk. 
+  serious legal risk.
 - Someone making credible threats of legal action where any form of
-  interaction with them on IETF mailing lists may have serious legal 
+  interaction with them on IETF mailing lists may have serious legal
   consequences for the IETF.
 
-If any such action is taken, the IETF LLC SHOULD inform the IESG as 
-soon as possible and SHOULD provide full details of the subject of 
-the action, nature of the action, reason for the action and expected 
-duration, except where it receives legal advice to the contrary. The 
-IETF LLC SHOULD also inform the moderator team and IETF community, 
-except where it receives legal advice to the contrary. 
+If any such action is taken, the IETF LLC SHOULD inform the IESG as
+soon as possible and SHOULD provide full details of the subject of
+the action, nature of the action, reason for the action and expected
+duration, except where it receives legal advice to the contrary. The
+IETF LLC SHOULD also inform the moderator team and IETF community,
+except where it receives legal advice to the contrary.
 
-As such an action would be taken by the IETF LLC in order to protect 
-the IETF according to its fiduciary duty, then it cannot allow that 
-to be overridden by a decision of the moderation team or the IESG. 
-The subject of any such action may request a review by the IETF LLC 
+As such an action would be taken by the IETF LLC in order to protect
+the IETF according to its fiduciary duty, then it cannot allow that
+to be overridden by a decision of the moderation team or the IESG.
+The subject of any such action may request a review by the IETF LLC
 board, as documented in section 4.7 of {{!RFC8711}}
 
-Any such action taken by the IETF LLC under this section of this 
+Any such action taken by the IETF LLC under this section of this
 policy, is not subject to the rest of the policy in this document.
 
 # Changes to Existing RFCs
@@ -442,6 +442,7 @@ These individuals suggested additional improvements to this document:
 - [Scope and relationship between WG chairs and moderators](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/76)
 - [Fix wording, spelling and capitalization.](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/88)
 - [Editorial changes to acknowledgments.](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/87)
+- [Update "Relation to the IETF LLC".](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/92)
 
 ## Since draft-ecahc-moderation-01
 


### PR DESCRIPTION
Updated this section as follows:
* Noted that this is for serious legal risk only.
* Removed list of types of behaviour that may trigger this as unnecessarily narrowing the scope.
* Noted expectation that the IETF LLC only acts when it has received legal advice that such action is *necessary*.
* Provided examples of when such an action is needed
* Added requirement for the IETF LLC to update the IESG as much as it is legally able to do.
* Replaced any mention of this being a temporary action that the moderation team then decides on as, by definition, this is an action that the IETF LLC has to take to protect the organization according to its fiduciary duty and that cannot be overridden by the moderation team.

I will also take this to the list.