### PR TITLE
Correct a statement that is logically redundant and add word "Immediately"

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -253,10 +253,10 @@ observe or are alerted to problematic behavior on such channels, they
 MUST consult with the group's management to jointly determine an
 appropriate response.
 
-Only when necessary MAY the moderators take actions against
-someone in a working group setting, but they MUST inform management of
-relevant groups, including WG chairs and area directors, when they do
-so.
+Moderators may take actions against
+someone in a working group setting, but they MUST immediately inform
+management of relevant groups, including WG chairs and area directors,
+when they do so.
 
 If working group management and moderators have a disagreement about
 how to proceed in any given circumstance, before any further action is


### PR DESCRIPTION
When is a moderator going to take an action unnecessarily?  So that there are no misunderstandings, if a moderator DOES take an action, make clear that they inform
the right people immediately.