### PR TITLE
Proposal for notification requirements

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -339,9 +339,17 @@ The moderator team is responsible to the IESG.  The IESG
 may create or designate a forum to facilitate discussion about
 moderation, and refer interested parties to that forum.
 
-All moderation actions that restrict posting rights shall be
-periodically reported to the IESG,
-as well as immediately to those against whom those actions take effect.
+Administrators and moderators have discretion to block unsolicited bulk email.
+Such actions do not need to follow the reporting requirements set out below.
+
+Moderation actions that reject or discard subsequent messages shall be reported
+immediately to those against whom those actions take effect. The moderator team's
+public process documentation shall describe notification policy for actions that
+delay messages by holding them for approval. The moderation team are expected to
+process all held messages in a timely manner.
+
+All moderation actions in the above paragraph shall be periodically reported to
+the IESG, including any cases where the affected person was not notified.
 
 To address inappropriate contributions in a timely manner, only
 moderation actions suspending participation rights for longer than


### PR DESCRIPTION
Following the brief discussion in the WG meeting, I offered to propose new wording. While considering what to write here, I realised that it would be good to give moderators discretion to take a light-touch approach in borderline cases. For example if a particular post is in the grey area between civil and uncivil, it may be useful to place the sender in hold for moderation for a few days so that if a subsequent message crosses the line, it can be prevented from reaching the list.

The alternative is that we require moderators to always notify the affected person about holds. If we take this route, moderators are likely to refrain from taking action in borderline cases, and wait until the line has been crossed. In this scenario some damage (e.g. to newcomer participation) is incurred.

I would appreciate WG thoughts on this wording.