### PR TITLE
Reword composition text

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -221,9 +221,6 @@ The IESG appoints and recalls moderators.
 In selecting members, the IESG will take into
 account geographic coverage, expected and unexpected absences, and
 team diversity.
-From time to time, the size of the moderator team may fall below
-five owing to changes in membership, but the IESG should endeavor
-to rapidly appoint new moderators to bring the size back up to five.
 
 The moderator team may expand or contract
 based on operational experience.  Apart from appointing and replacing


### PR DESCRIPTION
The composition text was somewhat unclear to me, and did not handle cases of resignations from the moderator team. The proposed new text attempts to resolve these issues while still providing the IESG with the flexibility to recall a moderator if needed.

This text was inspired by Section 3.1 of RFC 7776.