### PR TITLE
Attempt to address spt's comment.

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -631,8 +631,8 @@ is non-exhaustive.
 
 - Uncivil commentary, regardless of the general subject;
 
-- Announcements of conferences, events, or activities that are not
-  sponsored or endorsed by the Internet Society or IETF;
+- Unauthorized messages announcing conferences, events, or activities
+  that are not sponsored or endorsed by the Internet Society or IETF;
 
 - Repeatedly arguing counter to a WG charter that has been approved by
   the IESG; and


### PR DESCRIPTION
The TLS WG likes to allow pre-approved announcements. I'm sure there are other groups that do as well (DNS OARC, things like that).

https://mailarchive.ietf.org/arch/msg/mod-discuss/lDBRz4iWw077lYYNCgZjClY6OXY/

This is my attempt, feel free to change the wording.