### PR TITLE
Address comments from Chris Box and Brian Carpenter regarding the first point in Appendix C

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -626,8 +626,7 @@ ideal:
 The list below describes some types of disruptive behavior, but it
 is non-exhaustive.
 
-- Discussion of subjects unrelated to IETF policy, meetings,
-  activities, or technical concerns;
+- Persistent discussion of subjects unrelated to a group's charter;
 
 - Uncivil commentary, regardless of the general subject;
 


### PR DESCRIPTION
See the discussion here:

https://mailarchive.ietf.org/arch/msg/mod-discuss/t_lO3RgjlkeRztMb4NDh-kCzVRo/

This one is my fault, as I did indeed just copy/paste the old version from the IETF list policies.

Stephen Farrell raised the point that sometimes a group is chartered to define a charter, but I think we're still covered on that one, especially given the text on approved charters below.