### PR TITLE
Use 'must' instead of 'shall' for the 14 days thing

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -333,7 +333,7 @@ immediately to those against whom those actions take effect.
 
 To address disruptive behavior in a timely manner, only
 moderation actions suspending participation privileges for longer than
-fourteen (14) days shall be reported to the forum to which such an action applies.
+fourteen (14) days must be reported to the forum to which such an action applies.
 If such an action applies to more than one forum, it should be communicated to
 the community in a manner decided by the IESG.
 


### PR DESCRIPTION
This makes it clear moderators can go public in less than 14 days. See: 

https://mailarchive.ietf.org/arch/msg/mod-discuss/CmT0HJQCBdZuCDhBhfFKHz6lFIE/

(sorry to sully the empty GitHub issues/PRs)