### PR TITLE
Mention non-public mailing lists

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -289,6 +289,9 @@ the scope of this memo. Examples of actions that are out of scope include,
 but are not limited to, datatracker account removal, in-person meeting
 registration, content removal or redaction, moderation or policing of
 private or non-IETF communications, and redaction from IETF archives.
+While the moderator team does not moderate non-public IETF mailing
+lists, they can define processes that the administrators of such lists
+can choose to use.
 
 ## Unsolicted Bulk Messages
 

--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -290,8 +290,8 @@ but are not limited to, datatracker account removal, in-person meeting
 registration, content removal or redaction, moderation or policing of
 private or non-IETF communications, and redaction from IETF archives.
 While the moderator team does not moderate non-public IETF mailing
-lists, they can define processes that the administrators of such lists
-can choose to use.
+lists, the administrators of such lists can choose to adopt some of the
+processes that the moderator team develops.
 
 ## Unsolicted Bulk Messages
 


### PR DESCRIPTION
Add a small clarification that allows the moderator team to define processes similar to the deprecated PR-action. See [this mailing list thread](https://mailarchive.ietf.org/arch/msg/mod-discuss/OLun3abJEaTic_Tth8oJ682nlH0/) for more context. In particular, John Klensin [points out](https://mailarchive.ietf.org/arch/msg/mod-discuss/oRE7EJH-1CfqR-xBNi9CcrvZjF0/) that:

> I'd think that would work except that the last sentence of 3.1 seems to be quite clear, declaring "moderation or policing of private or non-IETF communications" out of scope.  So, if we want or need to have the moderation team design a PRa2 process that can be applied to private lists, we need to relax that statement a bit.

Closes #237