### PR TITLE
Make clear that moderation actions may be rescinded or amended.

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -330,7 +330,8 @@ these or other actions.
 
 The expectation is that the minimal actions necessary will be taken.
 Those who are directed to stop disrupting a forum must do so immediately.
-Further disruptions may lead to further corrective actions.
+Further disruptions may lead to further corrective actions.  Those who
+impose actions may rescind or amend them as circumstances warrant.
 
 All moderation actions that restrict participation privileges shall be
 periodically reported to the IESG,


### PR DESCRIPTION
This is the first of two separate PRs to address Pete Resnick's point.  This one states simply that moderator actions can be amended or rescinded.  The next one will look at addressing the situation when an admin wants to overturn a moderator action.  That is out of scope for this PR.