### PR TITLE
Last(?) bits from 2nd last call

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -531,6 +531,7 @@ These individuals contributed additional improvements:
 - [clarify when changes take effect](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/238/)
 - [Refine security considerations](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/239)
 - [Multi group and moderator reversal](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/257/files)
+- [Last(?) bits from 2nd last call](https://github.com/larseggert/draft-ietf-modpod-group-processes/pull/258)
 
 ## Since draft-ietf-modpod-group-processes-10
 


### PR DESCRIPTION
Address Mike Bishop / other comments

1. Require periodic aggregate reporting to the community.
2. While restrictions for under two weeks can remain private, at the request of the person being restricted, the information can be made public.
3. Administrators can reverse moderator actions, and like all other actions, disagreements should be resolved by the AD.
4. An editorial change that brings together text relating to "widest possible latitude" and taking least necessary action.
