### PR TITLE
Processes -> procedures

### DIFF
--- a/draft-ietf-modpod-group-processes.md
+++ b/draft-ietf-modpod-group-processes.md
@@ -114,7 +114,7 @@ the Internet Research Task Force (IRTF),
 the Internet Architecture Board (IAB),
 the RFC Series Working Group (RSWG), the RFC Series Approval Board (RSAB),
 or the Independent RFC Submission Stream, without their explicit agreement.
-These changes take effect when the processes described
+These changes take effect when the procedures described
 in {{prod}} have been approved by the IESG.
 
 ## Terminology Note


### PR DESCRIPTION
I checked each occurrence of "process" as discussed in the meeting at IETF 124, and changed those instances that referred to the output of the moderator team back to "procedure".